### PR TITLE
feat: restructured app based on standard practices

### DIFF
--- a/handler/todo.go
+++ b/handler/todo.go
@@ -1,89 +1,70 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"todos-api/db"
+	"todos-api/logic"
 	"todos-api/models"
 	"todos-api/utils"
 
-	"go.mongodb.org/mongo-driver/v2/bson"
-)
-
-type DatabaseTable string
-
-const (
-	TodosTable DatabaseTable = "todos"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func GetTodos(w http.ResponseWriter, r *http.Request) {
-	mongoClient := db.GetMongoClient()
-	cursor, err := mongoClient.Database("todos").Collection("todos").Find(context.Background(), bson.M{})
-	if err != nil {
-		fmt.Println(err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	result, error := logic.GetTodos()
+	if error != nil {
+		http.Error(w, error.Error(), http.StatusBadRequest)
 	}
 
-	defer cursor.Close(context.Background())
-
-	var todos []models.Todo
-	if err := cursor.All(context.Background(), &todos); err != nil {
-		fmt.Println(err)
-		http.Error(w, "Failed to decode todos", http.StatusInternalServerError)
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(todos)
+	json.NewEncoder(w).Encode(result)
 }
 
 func CreateTodo(w http.ResponseWriter, r *http.Request) {
-	mongoClient := db.GetMongoClient()
 	var todo models.Todo
 	if err := json.NewDecoder(r.Body).Decode(&todo); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
-
-	newTodo, err := mongoClient.Database(string(TodosTable)).Collection("todos").InsertOne(context.Background(), todo)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	result, error := logic.CreateTodo(todo)
+	if error != nil {
+		http.Error(w, error.Error(), http.StatusBadRequest)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(newTodo)
+	json.NewEncoder(w).Encode(result)
 }
 
 func UpdateTodo(w http.ResponseWriter, r *http.Request) {
-	mongoClient := db.GetMongoClient()
 	todoId := utils.GetIdFromPath(r.URL.Path)
-
-	fmt.Sprintln("Updating todo with id: %s", todoId)
 
 	var todo models.Todo
 	if err := json.NewDecoder(r.Body).Decode(&todo); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
-
-	updatedTodo, err := mongoClient.Database(string(TodosTable)).Collection("todos").UpdateOne(context.Background(), bson.M{"_id": todoId}, bson.M{"$set": todo})
+	// typecase todoId to bson.ObjectId
+	objID, err := primitive.ObjectIDFromHex(todoId)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
+	todo.Id = objID
+
+	result, error := logic.UpdateTodo(todo)
+	if error != nil {
+		http.Error(w, error.Error(), http.StatusBadRequest)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(updatedTodo)
+	json.NewEncoder(w).Encode(result)
 }
 
 func DeleteTodo(w http.ResponseWriter, r *http.Request) {
-	mongoClient := db.GetMongoClient()
 
 	todoId := utils.GetIdFromPath(r.URL.Path)
-	fmt.Sprintln("Deleting todo with id: %s", todoId)
-
-	deletedTodo, err := mongoClient.Database(string(TodosTable)).Collection("todos").DeleteOne(context.Background(), bson.M{"_id": todoId})
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	deletedTodo, error := logic.DeleteTodo(todoId)
+	if error != nil {
+		http.Error(w, error.Error(), http.StatusBadRequest)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/logic/todo.go
+++ b/logic/todo.go
@@ -1,0 +1,23 @@
+package logic
+
+import (
+	"todos-api/models"
+	"todos-api/protocol"
+)
+
+
+func GetTodos() ([]models.Todo, error) {
+	return protocol.List()
+}
+
+func CreateTodo(input models.Todo) (interface{}, error) {
+	return protocol.Create(input)
+}
+
+func UpdateTodo(input models.Todo) (interface{}, error) {
+	return protocol.Update(input)
+}
+
+func DeleteTodo(todoId string) (interface{}, error) {
+	return protocol.Delete(todoId)
+}

--- a/protocol/todo.go
+++ b/protocol/todo.go
@@ -1,0 +1,61 @@
+package protocol
+
+import (
+	"context"
+	"todos-api/db"
+	"todos-api/models"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type DatabaseTable string
+
+const (
+	TodosTable DatabaseTable = "todos"
+)
+
+func List() ([]models.Todo, error) {
+	mongoClient := db.GetMongoClient()
+	cursor, err := mongoClient.Database("todos").Collection("todos").Find(context.Background(), bson.M{})
+	if err != nil {
+		return nil, err
+	}
+
+	defer cursor.Close(context.Background())
+
+	var todos []models.Todo
+	if err := cursor.All(context.Background(), &todos); err != nil {
+		return nil, err
+	}
+	return todos, nil
+}
+
+func Create(input models.Todo) (interface{}, error)  {
+	mongoClient := db.GetMongoClient()
+
+	newTodo, err := mongoClient.Database(string(TodosTable)).Collection("todos").InsertOne(context.Background(), input)
+	if err != nil {
+		return nil, err
+	}
+	return newTodo, nil
+}
+
+func Update(input models.Todo) (interface{}, error) {
+	mongoClient := db.GetMongoClient()
+
+	updatedTodo, err := mongoClient.Database(string(TodosTable)).Collection("todos").UpdateOne(context.Background(), bson.M{"_id": input.Id}, bson.M{"$set": input})
+	if err != nil {
+		return nil, err
+	}
+	return updatedTodo, nil
+}
+
+func Delete(todoId string) (interface{}, error) {
+	mongoClient := db.GetMongoClient()
+
+	deletedTodo, err := mongoClient.Database(string(TodosTable)).Collection("todos").DeleteOne(context.Background(), bson.M{"_id": todoId})
+	if err != nil {
+		return nil, err
+	}
+	return deletedTodo, nil
+}


### PR DESCRIPTION
### What this does
In last code review from @MysteryMachine , I got feedback to restructure app based on the principles we have in our Copilot monorepo. This involved creating directories based on separation of concerns. With this PR, we've following directories:
| Directory | Purpose |
|--------|--------|
| handler | Responsible for marshalling/unmarshalling input and passing correct models to logic |
| logic | Mostly business logic. I didn't have much in my case |
| protocol | DB interactions and all things MongoDB |

I think this is now in a lot better place where files are organized correctly. I've tested this by running on Hoppscotch and found everything working.

### Testing
<img width="2556" alt="image" src="https://github.com/user-attachments/assets/50143eff-cd91-4629-bacf-01969376ed91" />
